### PR TITLE
Improved the implementation of `expectAssertion` 

### DIFF
--- a/tests/helpers/module-for-assert.js
+++ b/tests/helpers/module-for-assert.js
@@ -1,8 +1,10 @@
+import { moduleForComponent } from 'ember-qunit';
 import { module } from 'qunit';
 
 
 export default function(name, options = {}) {
-  module(name, {
+  let opts = {
+    integration: options.integration,
     beforeEach(assert) {
       let originalPushResult = assert.pushResult;
       this.pushedResults = [];
@@ -30,5 +32,12 @@ export default function(name, options = {}) {
         return options.afterEach.apply(this, arguments);
       }
     }
-  });
+  };
+
+  if (opts.integration) {
+    // Really we just want to use an integration loop, but we have to have a target for the moduleFor.
+    moduleForComponent('component:x-assert-helpers', name, opts);
+  } else {
+    module(name, opts);
+  }
 }

--- a/tests/integration/assertion-test.js
+++ b/tests/integration/assertion-test.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import { test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import moduleForAssert from '../helpers/module-for-assert';
+
+
+moduleForAssert('Integration: Assertion', {
+  integration: true,
+  beforeEach() {
+    this.register('component:x-assert-test', Ember.Component.extend({
+      init() {
+        this._super();
+        Ember.assert('x-assert-test will always assert');
+      }
+    }));
+  }
+});
+
+test('Check for assert', function(assert) {
+  assert.expectAssertion(() => {
+    this.render(hbs`{{x-assert-test}}`);
+  }, /x-assert-test will always assert/);
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  assert.ok(this.pushedResults[0].result, '`expectWarning` captured warning call');
+});

--- a/tests/unit/assertion-test.js
+++ b/tests/unit/assertion-test.js
@@ -2,8 +2,7 @@ import Ember from 'ember';
 import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
-
-moduleForAssert('Assertion');
+moduleForAssert('Assertion', { integration: false });
 
 test('expectAssertion called with assert', function(assert) {
   assert.expectAssertion(() => {

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -3,7 +3,7 @@ import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
 
-moduleForAssert('Deprecation Assert');
+moduleForAssert('Deprecation Assert', { integration: false });
 
 test('expectDeprecation called after test and with deprecation', function(assert) {
   Ember.deprecate('Something deprecated', false, { id: 'deprecation-test', until: '3.0.0' });

--- a/tests/unit/run-loop-test.js
+++ b/tests/unit/run-loop-test.js
@@ -3,7 +3,7 @@ import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
 
-moduleForAssert('Run Loop Assert');
+moduleForAssert('Run Loop Assert', { integration: false });
 
 test('`expectNoRunLoop` in a run loop', function(assert) {
   Ember.run.begin();

--- a/tests/unit/warning-test.js
+++ b/tests/unit/warning-test.js
@@ -3,7 +3,7 @@ import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
 
-moduleForAssert('Warning Assert');
+moduleForAssert('Warning Assert', { integration: false });
 
 test('expectWarning called after test and with warning', function(assert) {
   Ember.warn('Something warned', false, { id: 'warning-test', until: '3.0.0' });


### PR DESCRIPTION
This is to handle assertions thrown inside of a runloop during an integration test. Related to: https://github.com/emberjs/ember.js/pull/14898 .