### PR TITLE
Fixing #7.

### DIFF
--- a/addon-test-support/asserts/deprecation.js
+++ b/addon-test-support/asserts/deprecation.js
@@ -10,7 +10,10 @@ export default function() {
   });
 
   Ember.Debug.registerDeprecationHandler(function(message, options, next) {
-    deprecations.push({ message, options });
+    // It's possible for deprecations to trigger before the test has started.
+    if (deprecations) {
+      deprecations.push({ message, options });
+    }
     next(message, options);
   });
 

--- a/addon-test-support/asserts/warning.js
+++ b/addon-test-support/asserts/warning.js
@@ -10,7 +10,10 @@ export default function() {
   });
 
   Ember.Debug.registerWarnHandler(function(message, options, next) {
-    warnings.push({ message, options });
+    // It's possible for warnings to trigger before the test has started.
+    if (warnings) {
+      warnings.push({ message, options });
+    }
     next(message, options);
   });
 

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
+// ............................................................
+// Deprecation outside of a test. Should not cause test failures.
+Ember.deprecate('Deprecation outside of a test', false, { id: 'deprecation-test', until: '3.0.0' });
+// ............................................................
 
 moduleForAssert('Deprecation Assert', { integration: false });
 

--- a/tests/unit/warning-test.js
+++ b/tests/unit/warning-test.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 import { test } from 'ember-qunit';
 import moduleForAssert from '../helpers/module-for-assert';
 
+// ............................................................
+// Warning outside of a test. Should not cause test failures.
+Ember.warn('Warning outside of a test', false, { id: 'warning-test', until: '3.0.0' });
+// ............................................................
 
 moduleForAssert('Warning Assert', { integration: false });
 


### PR DESCRIPTION
 Ensure that deprecations and warnings that take place outside the test scope do not cause issues.