### PR TITLE
WIP async support

### DIFF
--- a/addon-test-support/asserts/assertion.js
+++ b/addon-test-support/asserts/assertion.js
@@ -8,54 +8,73 @@ let TestAdapter = QUnitAdapter.extend({
   }
 });
 
+let isProductionBuild = (function() {
+  try {
+    Ember.assert('fails in debug builds');
+  } catch(e) {
+    return false;
+  }
+
+  return true;
+})();
+
 export default function() {
-  let isProductionBuild = (function() {
-    try {
-      Ember.assert('fails in debug builds');
-    } catch(e) {
-      return false;
-    }
-
-    return true;
-  })();
-
   QUnit.assert.expectAssertion = function(cb, matcher) {
+    let assertion = this;
     // Save off the original adapter and replace it with a test one.
     let origTestAdapter = Ember.Test.adapter;
     Ember.run(() => { Ember.Test.adapter = TestAdapter.create(); });
 
     let error = null;
+    let ret;
     try {
-      cb();
+      ret = cb();
     } catch (e) {
       error = e;
     } finally {
       error = error || Ember.Test.adapter.lastError;
     }
 
-    let isEmberError = error instanceof Ember.Error;
-    let matches = Boolean(isEmberError && error.message.match(matcher));
-
-    if (isProductionBuild) {
-      this.pushResult({
-        result: true,
-        actual: null,
-        expected: null,
-        message: 'Assertions are disabled in production builds.'
-      });
+    if (typeof ret === 'object' && ret !== null && typeof ret.then === 'function') {
+      // handle async
+      return Ember.RSVP.Promise((resolve, reject) => {
+        if (error) reject(error)
+        else resolve(ret);
+      }).catch(reason => {
+          handleError(assertion, reason, matcher)
+        }).finally(() => cleanup(origTestAdapter));;
     } else {
-      this.pushResult({
-        result: isEmberError && matches,
-        actual: error && error.message,
-        expected: matcher,
-        message: matcher ? 'Ember.assert matched specific message' : 'Ember.assert called with any message'
-      });
+        handleError(assertion, error, matcher);
+        cleanup(origTestAdapter);
     }
-
-    // Cleanup the test adapter and restore the original.
-    Ember.run(() => {
-      Ember.Test.adapter.destroy();
-      Ember.Test.adapter = origTestAdapter;
-    });
   };
+}
+
+function handleError(assertion, error, matcher) {
+  let isEmberError = error instanceof Ember.Error;
+  let matches = Boolean(isEmberError && error.message.match(matcher));
+
+  if (isProductionBuild) {
+    assertion.pushResult({
+      result: true,
+      actual: null,
+      expected: null,
+      message: 'Assertions are disabled in production builds.'
+    });
+  } else {
+    assertion.pushResult({
+      result: isEmberError && matches,
+      actual: error && error.message,
+      expected: matcher,
+      message: matcher ? 'Ember.assert matched specific message' : 'Ember.assert called with any message'
+    });
+  }
+}
+
+function cleanup(origTestAdapter) {
+  // Cleanup the test adapter and restore the original.
+  Ember.run(() => {
+    Ember.Test.adapter.destroy();
+    Ember.Test.adapter = origTestAdapter;
+  });
 }


### PR DESCRIPTION
this is still WIP.

### Plan:

add async support to the various helpers, so that we can more easily use them in ember-data.

for example:
```js
return assert.expectAssertion(() => {
  return store.somethingThatEventuallyAsserts();
});
```

- [ ] complete functionality
- [ ] ensure test have been added.