### PR TITLE
Enhance README for expectAssertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ember install ember-qunit-assert-helpers
 
 `assert.expectAssertion(callback, matcher)`
 
-Asserts that `Ember.assert` did throw an error. An optional matcher can be provided to match a specific error message.
+Asserts that `Ember.assert` did throw an error. An optional regular expression matcher can be provided to match a specific error message.
 
 ```javascript
 test('triggers Ember.assert', function(assert) {
@@ -26,8 +26,8 @@ test('triggers Ember.assert', function(assert) {
   });
 
   assert.expectAssertion(() => {
-    Ember.assert('You forgot the required parameter');
-  }, 'required parameter');
+    Ember.assert('You forgot "bar", the required parameter');
+  }, /You forgot "\w+", the required parameter/);
 })
 ```
 


### PR DESCRIPTION
- As per [this issue](https://github.com/workmanw/ember-qunit-assert-helpers/issues/11) it is not very clear from the documentation how is expectAssertion
expected to use.
- This PR adds explicit statement that the matcher should be regular
expression.
- Also adds more explicit example to show the possibilities when
matching regular expressions.