### PR TITLE
Failing test for expectAssertion matcher special cases

### DIFF
--- a/tests/integration/assertion-test.js
+++ b/tests/integration/assertion-test.js
@@ -3,6 +3,7 @@ import { test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moduleForAssert from '../helpers/module-for-assert';
 
+let assertMessage = 'x-assert-test will always [assert]';
 
 moduleForAssert('Integration: Assertion', {
   integration: true,
@@ -10,7 +11,7 @@ moduleForAssert('Integration: Assertion', {
     this.register('component:x-assert-test', Ember.Component.extend({
       init() {
         this._super();
-        Ember.assert('x-assert-test will always assert');
+        Ember.assert(assertMessage);
       }
     }));
   }
@@ -19,10 +20,23 @@ moduleForAssert('Integration: Assertion', {
 test('Check for assert', function(assert) {
   assert.expectAssertion(() => {
     this.render(hbs`{{x-assert-test}}`);
-  }, /x-assert-test will always assert/);
+  }, /x-assert-test will always/);
 
   // Restore the asserts (removes the mocking)
   this.restoreAsserts();
 
   assert.ok(this.pushedResults[0].result, '`expectWarning` captured warning call');
+});
+
+test('False match', function(assert) {
+  assert.expectAssertion(() => {
+    this.render(hbs`{{x-assert-test}}`);
+  }, assertMessage);
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  let expected = `Assertion Failed: ${assertMessage}`;
+  assert.notOk(this.pushedResults[0].result, '`expectWarning` captured that the matcher does not match assertion string');
+  assert.notEqual(expected, this.pushedResults[0].actual, '`expectAssertion` actual value and expected should not be identical');
 });


### PR DESCRIPTION
- You can construct matcher that will match perfectly assert failing
message (by string comparison) and yet it will not match it on regular
expression level.
- This can lead to confustion when constructing tests, because strings can be identical and yet the test will render ass failed.
- This PR does not propose a solution, because there are multiple:
  - Prepend string in front of matcher before [pushing it to
results](https://github.com/workmanw/ember-qunit-assert-helpers/blob/master/addon-test-support/asserts/assertion.js#L50) so that test gui will never show them as matching.
   - Disallow string as matchers - more explicit, less confusion. Although it's not 100%
   - Explicitly allow string matchers for simple cases?

- For details see: https://github.com/workmanw/ember-qunit-assert-helpers/issues/11