### PR TITLE
Addresses #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ember install ember-qunit-assert-helpers
 
 `assert.expectAssertion(callback, matcher)`
 
-Asserts that `Ember.assert` did throw an error. An optional regular expression matcher can be provided to match a specific error message.
+Asserts that `Ember.assert` did throw an error. An optional string or regular expression matcher can be provided to match a specific error message.
 
 ```javascript
 test('triggers Ember.assert', function(assert) {
@@ -50,7 +50,7 @@ test('`Ember.deprecate` was called anytime during the test and matched', functio
 
 `assert.expectDeprecation(callback, matcher)`
 
-Asserts that `Ember.deprecate` was called. An optional callback can be provided. An optional matcher can also be provided.
+Asserts that `Ember.deprecate` was called. An optional callback can be provided. An optional string or regular expression matcher can also be provided.
 
 ```javascript
 test('`Ember.deprecate` was called anytime during the test', function(assert) {

--- a/addon-test-support/-private/utils.js
+++ b/addon-test-support/-private/utils.js
@@ -1,0 +1,16 @@
+function includes(message, search) {
+  return message.includes ? message.includes(search) : message.indexOf(search) !== -1;
+}
+
+export function checkMatcher(message, matcher) {
+  if (typeof matcher === 'string') {
+    return includes(message, matcher);
+  } else if (matcher instanceof RegExp) {
+    return !!message.match(matcher);
+  } else if (matcher) {
+    throw new Error(`ember-qunit-assert-helpers can only match Strings and RegExps. "${typeof matcher}" was provided.`);
+  }
+
+  // No matcher always returns true. Makes the code easier elsewhere.
+  return true;
+}

--- a/addon-test-support/asserts/assertion.js
+++ b/addon-test-support/asserts/assertion.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import QUnit from 'qunit';
 import { QUnitAdapter } from 'ember-qunit';
+import { checkMatcher } from '../-private/utils';
+
 
 let TestAdapter = QUnitAdapter.extend({
   exception(error) {
@@ -40,7 +42,7 @@ export default function() {
     }
 
     let isEmberError = error instanceof Ember.Error;
-    let matches = Boolean(isEmberError && error.message.match(matcher));
+    let matches = Boolean(isEmberError && checkMatcher(error.message, matcher));
 
     if (isProductionBuild) {
       this.pushResult({

--- a/addon-test-support/asserts/deprecation.js
+++ b/addon-test-support/asserts/deprecation.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import QUnit from 'qunit';
+import { checkMatcher } from '../-private/utils';
 
 
 export default function() {
@@ -18,7 +19,9 @@ export default function() {
   });
 
   function assertDeprecations(qunitAssert, matcher) {
-    let matchedDeprecations = deprecations.filter(deprecation => deprecation.message.match(matcher));
+    let matchedDeprecations = deprecations.filter(deprecation => {
+      return checkMatcher(deprecation.message, matcher);
+    });
     qunitAssert.pushResult({
       result: matchedDeprecations.length !== 0,
       actual: matchedDeprecations,

--- a/addon-test-support/asserts/warning.js
+++ b/addon-test-support/asserts/warning.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import QUnit from 'qunit';
+import { checkMatcher } from '../-private/utils';
 
 
 export default function() {
@@ -18,7 +19,9 @@ export default function() {
   });
 
   function assertWarnings(qunitAssert, matcher) {
-    let matchedWarnings = warnings.filter(warning => warning.message.match(matcher));
+    let matchedWarnings = warnings.filter(warning => {
+      return checkMatcher(warning.message, matcher);
+    });
     qunitAssert.pushResult({
       result: matchedWarnings.length !== 0,
       actual: matchedWarnings,

--- a/tests/unit/assertion-test.js
+++ b/tests/unit/assertion-test.js
@@ -37,7 +37,6 @@ test('expectAssertion called with deprecation and matched assert', function(asse
   assert.ok(this.pushedResults[0].result, '`expectAssertion` captured deprecation call');
 });
 
-
 test('expectAssertion called with deprecation and unmatched assert', function(assert) {
   assert.expectAssertion(() => {
     Ember.assert('testing assert');

--- a/tests/unit/deprecation-test.js
+++ b/tests/unit/deprecation-test.js
@@ -160,3 +160,34 @@ test('expectNoDeprecation called with callback and after test', function(assert)
   assert.notOk(this.pushedResults[0].result, 'first `expectNoDeprecation` caught logged failed result');
   assert.ok(this.pushedResults[1].result, 'second `expectNoDeprecation` caught no deprecation');
 });
+
+test('expectDeprecation with regex matcher', function(assert) {
+  assert.expectDeprecation(() => {
+    Ember.deprecate('Something deprecated', false, { id: 'deprecation-test', until: '3.0.0' });
+  }, /Somethi[a-z ]*ecated/);
+  assert.expectDeprecation(() => {
+    Ember.deprecate('/Something* deprecated/', false, { id: 'deprecation-test', until: '3.0.0' });
+  }, /Something* deprecated/);
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  assert.ok(this.pushedResults[0].result, '`expectDeprecation` matched RegExp');
+  assert.notOk(this.pushedResults[1].result, '`expectDeprecation` didn\'t RegExp as String match');
+});
+
+test('expectDeprecation with string matcher', function(assert) {
+  assert.expectDeprecation(() => {
+    Ember.deprecate('Something deprecated', false, { id: 'deprecation-test', until: '3.0.0' });
+  }, 'Something');
+
+  assert.expectDeprecation(() => {
+    Ember.deprecate('Something deprecated', false, { id: 'deprecation-test', until: '3.0.0' });
+  }, 'Something.*');
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  assert.ok(this.pushedResults[0].result, '`expectDeprecation` captured deprecation for partial String match');
+  assert.notOk(this.pushedResults[1].result, '`expectDeprecation` didn\'t test a String match as RegExp');
+});

--- a/tests/unit/warning-test.js
+++ b/tests/unit/warning-test.js
@@ -160,3 +160,36 @@ test('expectNoWarning called with callback and after test', function(assert) {
   assert.notOk(this.pushedResults[0].result, 'first `expectNoWarning` caught logged failed result');
   assert.ok(this.pushedResults[1].result, 'second `expectNoWarning` caught no warning');
 });
+
+
+test('expectWarning with regex matcher', function(assert) {
+  assert.expectWarning(() => {
+    Ember.warn('Something warned', false, { id: 'warning-test', until: '3.0.0' });
+  }, /Somethi[a-z ]*rned/);
+  assert.expectWarning(() => {
+    Ember.deprecate('/Something* warned/', false, { id: 'warning-test', until: '3.0.0' });
+  }, /Something* warned/);
+
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  assert.ok(this.pushedResults[0].result, '`expectWarning` matched RegExp');
+  assert.notOk(this.pushedResults[1].result, '`expectWarning` didn\'t RegExp as String match');
+});
+
+test('expectWarning with string matcher', function(assert) {
+  assert.expectWarning(() => {
+    Ember.warn('Something warned', false, { id: 'warning-test', until: '3.0.0' });
+  }, 'Something');
+
+  assert.expectWarning(() => {
+    Ember.warn('Something warned', false, { id: 'warning-test', until: '3.0.0' });
+  }, 'Something.*');
+
+  // Restore the asserts (removes the mocking)
+  this.restoreAsserts();
+
+  assert.ok(this.pushedResults[0].result, '`expectWarning` captured warning for partial string match');
+  assert.notOk(this.pushedResults[1].result, '`expectWarning` didn\'t test a string match as RegExp');
+});


### PR DESCRIPTION
Ensure that strings provided to `expectAssertion`, `expectDeprecation` and `expectWarning` are only used for partial matching and not treated as regular expressions. 