### PR TITLE
Check if `_requireBuildPackages()` exists before calling it

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ module.exports = {
   name: 'ember-qunit-assert-helpers',
 
   postprocessTree(type, tree) {
-    this._requireBuildPackages();
+    if (this._requireBuildPackages) {
+      this._requireBuildPackages();
+    }
+
     if (type === 'all' && this.app.tests) {
       var appendPath = path.join(__dirname, '/vendor/ember-qunit-assert-helpers-loader.js');
       return new Append(tree, /test-support[A-Za-z0-9-]*/, appendPath);


### PR DESCRIPTION
This is needed to make the project compatible with Ember CLI 3.7+

Resolves #26 

/cc @workmanw  @rwjblue 