### PR TITLE
fix(build): `ember-auto-import@2` compatibility

### DIFF
--- a/vendor/ember-qunit-assert-helpers-loader.js
+++ b/vendor/ember-qunit-assert-helpers-loader.js
@@ -1,4 +1,21 @@
-/* globals require */
-
-// Loading the file here will install the asserts onto `QUnit.Assert` class.
-require('ember-qunit-assert-helpers/test-support/install-qunit-asserts');
+// This file is appended to `test-support.js`.
+// It automatically requires the `install-qunit-asserts` entrypoint module to
+// install the assertions onto `Qunit`.
+//
+// With `ember-auto-import@1` all vanilla JS dependencies, like `qunit`, are
+// eagerly bundled into either `vendor.js` or `test-support.js`.
+// Therefore they are available, when this module is evaluated.
+//
+// With `ember-auto-import@2` these dependencies are placed into extra
+// `*.chunk.js` files instead. These files are loaded _after_ `vendor.js` and
+// `test-support.js`. Therefore they are not available, when this module is
+// evaluated.
+// To fix this, we delay the evaluation of the entry point until the
+// `DOMContentLoaded` event occurs, by which all `<script>` tags will have been
+// loaded.
+//
+// This is not an ideal solution, but only a temporary fix with minimal changes
+// to make this addon work with `ember-auto-import@2` host apps.
+document.addEventListener('DOMContentLoaded', () => {
+  require('ember-qunit-assert-helpers/test-support/install-qunit-asserts');
+});


### PR DESCRIPTION
Makes this addon compatible with [`ember-auto-import@2`](https://github.com/ef4/ember-auto-import/blob/main/docs/upgrade-guide-2.0.md#readme) host apps.

Closes #25.

This is not the [ideal solution](https://github.com/simplabs/qunit-dom#ember-projects-using-ember-qunit-v5x-and-above), but the most trivial one.

As this addon is considered dormant and its features are set to be [upstreamed into `ember-qunit`](https://github.com/emberjs/ember-qunit/pull/868), I don't expect the owner @workmanw to cut a new release. Instead affected users may use [`patch-package`](https://github.com/ds300/patch-package#readme) to apply this fix locally.